### PR TITLE
Feat: [#86] 멘토링 신청, 조회 관련 API 구현

### DIFF
--- a/server/wordi/src/main/java/com/pm/wordi/commons/advice/ExceptionAdvice.java
+++ b/server/wordi/src/main/java/com/pm/wordi/commons/advice/ExceptionAdvice.java
@@ -5,6 +5,7 @@ import com.pm.wordi.exception.EncryptException;
 import com.pm.wordi.exception.mentor.ExistMentorException;
 import com.pm.wordi.exception.mentor.NoExistMentorException;
 import com.pm.wordi.exception.mentor.NoExistMentoringProfileException;
+import com.pm.wordi.exception.mentoring.EqualUserMentorException;
 import com.pm.wordi.exception.user.*;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.InvalidDataAccessApiUsageException;
@@ -78,6 +79,12 @@ public class ExceptionAdvice {
         return new ResponseEntity<>(e.getMessage(), HttpStatus.CONFLICT);
     }
 
+    // == Mentoring
+    @ExceptionHandler(EqualUserMentorException.class)
+    public ResponseEntity<String> equalUserMentorException(EqualUserMentorException e) {
+        return new ResponseEntity<>(e.getMessage(), HttpStatus.CONFLICT);
+    }
+
 
 
     // == client ==
@@ -91,6 +98,7 @@ public class ExceptionAdvice {
     // 잘못된 JSON 문법 요청 에러
     @ExceptionHandler(HttpMessageNotReadableException.class)
     public ResponseEntity<String> httpMessageNotReadableException(HttpMessageNotReadableException e) {
+        e.printStackTrace();
         return BAD_JSON_GRAMMAR;
     }
 
@@ -100,7 +108,6 @@ public class ExceptionAdvice {
     @ExceptionHandler(Exception.class)
     public ResponseEntity<String> exception(Exception e) {
         e.printStackTrace();
-        log.error("에러 메세지", e.getMessage());
         return new ResponseEntity<>("등록되지 않은 에러입니다.", HttpStatus.INTERNAL_SERVER_ERROR);
     }
 

--- a/server/wordi/src/main/java/com/pm/wordi/controller/MentorApiController.java
+++ b/server/wordi/src/main/java/com/pm/wordi/controller/MentorApiController.java
@@ -32,7 +32,7 @@ public class MentorApiController {
                                                    HttpServletRequest request) {
         Long userId = (Long)request.getAttribute("userId");
         mentorService.createMentor(userId, createRequest);
-        return RESPONSE_OK;
+        return RESPONSE_CREATED;
     }
 
     /**

--- a/server/wordi/src/main/java/com/pm/wordi/controller/MentorApiController.java
+++ b/server/wordi/src/main/java/com/pm/wordi/controller/MentorApiController.java
@@ -80,4 +80,6 @@ public class MentorApiController {
         return ResponseEntity.ok(mentorService.getMentoringProfile(mentorId));
     }
 
+
+
 }

--- a/server/wordi/src/main/java/com/pm/wordi/controller/MentoringApiController.java
+++ b/server/wordi/src/main/java/com/pm/wordi/controller/MentoringApiController.java
@@ -58,6 +58,17 @@ public class MentoringApiController {
         return ResponseEntity.ok(mentoringService.geMentoringListBytMentor(userId));
     }
 
+    /**
+     * 유저 - 멘토링 내역 조회 API
+     * [GET] /app/users/mentorings
+     * @return BaseResponse<List<UserMentoringRes>>
+     */
+    @GetMapping("/app/users/mentorings")
+    public ResponseEntity<List<UserMentoringRes>> geMentoringListByUser(HttpServletRequest request) {
+        Long userId = (Long)request.getAttribute("userId");
+        return ResponseEntity.ok(mentoringService.geMentoringListByUser(userId));
+    }
+
 
 
 }

--- a/server/wordi/src/main/java/com/pm/wordi/controller/MentoringApiController.java
+++ b/server/wordi/src/main/java/com/pm/wordi/controller/MentoringApiController.java
@@ -1,8 +1,6 @@
 package com.pm.wordi.controller;
 
 
-import com.pm.wordi.controller.dto.MentorDto;
-import com.pm.wordi.controller.dto.MentoringDto;
 import com.pm.wordi.service.MentoringService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -12,11 +10,12 @@ import org.springframework.web.bind.annotation.*;
 
 import javax.servlet.http.HttpServletRequest;
 
+import java.util.List;
+
 import static com.pm.wordi.commons.utils.constants.ResponseConstants.RESPONSE_CREATED;
 import static com.pm.wordi.controller.dto.MentoringDto.*;
 
 @RestController
-@RequestMapping("/app/mentors/{mentorId}/applications")
 @RequiredArgsConstructor
 public class MentoringApiController {
 
@@ -27,12 +26,12 @@ public class MentoringApiController {
      * [POST] /app/mentors/{mentorId}/applications
      * @return BaseResponse<HttpStatus>
      */
-    @PostMapping("")
-    public ResponseEntity<HttpStatus> createMentoring(@Validated @RequestBody CreateRequest createRequest,
+    @PostMapping("/app/mentors/{mentorId}/applications")
+    public ResponseEntity<HttpStatus> createMentoring(@Validated @RequestBody ApplicationReq applicationReq,
                                                       @PathVariable Long mentorId,
                                                       HttpServletRequest request) {
         Long userId = (Long)request.getAttribute("userId");
-        mentoringService.createMentoring(mentorId, userId, createRequest);
+        mentoringService.createMentoring(mentorId, userId, applicationReq);
         return RESPONSE_CREATED;
     }
 
@@ -41,11 +40,24 @@ public class MentoringApiController {
      * [GET] /app/mentors/{mentorId}/applications
      * @return BaseResponse<MentoringRes>
      */
-    @GetMapping("")
-    public ResponseEntity<MentoringRes> getMentoring(@PathVariable Long mentorId,
-                                                     HttpServletRequest request) {
+    @GetMapping("/app/mentors/{mentorId}/applications")
+    public ResponseEntity<ApplicationRes> getMentoring(@PathVariable Long mentorId,
+                                                       HttpServletRequest request) {
         Long userId = (Long)request.getAttribute("userId");
         return ResponseEntity.ok(mentoringService.getMentoring(mentorId, userId));
     }
+
+    /**
+     * 멘토 - 멘토링 내역 조회 API
+     * [GET] /app/mentors/mentorings
+     * @return BaseResponse<List<MentorMentoringRes>>
+     */
+    @GetMapping("/app/mentors/mentorings")
+    public ResponseEntity<List<MentorMentoringRes>> geMentoringListBytMentor(HttpServletRequest request) {
+        Long userId = (Long)request.getAttribute("userId");
+        return ResponseEntity.ok(mentoringService.geMentoringListBytMentor(userId));
+    }
+
+
 
 }

--- a/server/wordi/src/main/java/com/pm/wordi/controller/MentoringApiController.java
+++ b/server/wordi/src/main/java/com/pm/wordi/controller/MentoringApiController.java
@@ -7,6 +7,7 @@ import com.pm.wordi.service.MentoringService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 import javax.servlet.http.HttpServletRequest;
@@ -27,12 +28,24 @@ public class MentoringApiController {
      * @return BaseResponse<HttpStatus>
      */
     @PostMapping("")
-    public ResponseEntity<HttpStatus> createMentoring(@RequestBody CreateRequest createRequest,
+    public ResponseEntity<HttpStatus> createMentoring(@Validated @RequestBody CreateRequest createRequest,
                                                       @PathVariable Long mentorId,
                                                       HttpServletRequest request) {
         Long userId = (Long)request.getAttribute("userId");
         mentoringService.createMentoring(mentorId, userId, createRequest);
         return RESPONSE_CREATED;
+    }
+
+    /**
+     * 멘토링 신청 페이지 API
+     * [GET] /app/mentors/{mentorId}/applications
+     * @return BaseResponse<MentoringRes>
+     */
+    @GetMapping("")
+    public ResponseEntity<MentoringRes> getMentoring(@PathVariable Long mentorId,
+                                                     HttpServletRequest request) {
+        Long userId = (Long)request.getAttribute("userId");
+        return ResponseEntity.ok(mentoringService.getMentoring(mentorId, userId));
     }
 
 }

--- a/server/wordi/src/main/java/com/pm/wordi/controller/MentoringApiController.java
+++ b/server/wordi/src/main/java/com/pm/wordi/controller/MentoringApiController.java
@@ -1,0 +1,38 @@
+package com.pm.wordi.controller;
+
+
+import com.pm.wordi.controller.dto.MentorDto;
+import com.pm.wordi.controller.dto.MentoringDto;
+import com.pm.wordi.service.MentoringService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import javax.servlet.http.HttpServletRequest;
+
+import static com.pm.wordi.commons.utils.constants.ResponseConstants.RESPONSE_CREATED;
+import static com.pm.wordi.controller.dto.MentoringDto.*;
+
+@RestController
+@RequestMapping("/app/mentors/{mentorId}/applications")
+@RequiredArgsConstructor
+public class MentoringApiController {
+
+    private final MentoringService mentoringService;
+
+    /**
+     * 멘토링 신청 API
+     * [POST] /app/mentors/{mentorId}/applications
+     * @return BaseResponse<HttpStatus>
+     */
+    @PostMapping("")
+    public ResponseEntity<HttpStatus> createMentoring(@RequestBody CreateRequest createRequest,
+                                                      @PathVariable Long mentorId,
+                                                      HttpServletRequest request) {
+        Long userId = (Long)request.getAttribute("userId");
+        mentoringService.createMentoring(mentorId, userId, createRequest);
+        return RESPONSE_CREATED;
+    }
+
+}

--- a/server/wordi/src/main/java/com/pm/wordi/controller/dto/MentorDto.java
+++ b/server/wordi/src/main/java/com/pm/wordi/controller/dto/MentorDto.java
@@ -14,6 +14,7 @@ import javax.persistence.*;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
@@ -43,6 +44,7 @@ public class MentorDto {
 
         private List<String> keywordList = new ArrayList<>();
 
+        @Size(max = 100, message = "멘토 프로필 소개는 최대 100자입니다.")
         @NotBlank(message = "멘토 프로필 소개를 입력해주세요.")
         private String profileIntroduction;
 

--- a/server/wordi/src/main/java/com/pm/wordi/controller/dto/MentoringDto.java
+++ b/server/wordi/src/main/java/com/pm/wordi/controller/dto/MentoringDto.java
@@ -1,0 +1,74 @@
+package com.pm.wordi.controller.dto;
+
+import com.pm.wordi.domain.BaseStatus;
+import com.pm.wordi.domain.mentor.Mentor;
+import com.pm.wordi.domain.mentoring.Mentoring;
+import com.pm.wordi.domain.mentoring.MentoringStatus;
+import com.pm.wordi.domain.mentoring.Payment;
+import com.pm.wordi.domain.mentoring.PaymentStatus;
+import com.pm.wordi.domain.user.User;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import java.time.LocalDateTime;
+
+public class MentoringDto {
+
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    public static class CreateRequest {
+
+        private Long price;
+        @DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
+        private LocalDateTime requestSchedule1;
+        @DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
+        private LocalDateTime requestSchedule2;
+        private String questions;
+        private paymentDTO payment;
+
+        public Mentoring toEntity(User user, Mentor mentor, Payment payment) {
+
+            return Mentoring.builder()
+                    .user(user)
+                    .mentor(mentor)
+                    .payment(payment)
+                    .price(this.price)
+                    .requestSchedule1(this.requestSchedule1)
+                    .requestSchedule2(this.requestSchedule2)
+                    .questions(this.questions)
+                    .mentoringStatus(MentoringStatus.승인대기)
+                    .status(BaseStatus.ACTIVE)
+                    .build();
+
+        }
+
+    }
+
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    public static class paymentDTO {
+        private String orderNumber;
+        private Long price;
+        private String depositor;
+        private String bankCode;
+        private String accountNumber;
+
+        public Payment toEntity(User user) {
+            return Payment.builder()
+                    .user(user)
+                    .orderNumber(this.orderNumber)
+                    .price(this.price)
+                    .depositor(this.depositor)
+                    .bankCode(this.bankCode)
+                    .accountNumber(this.accountNumber)
+                    .paymentStatus(PaymentStatus.결제보류)
+                    .status(BaseStatus.ACTIVE)
+                    .build();
+        }
+    }
+}

--- a/server/wordi/src/main/java/com/pm/wordi/controller/dto/MentoringDto.java
+++ b/server/wordi/src/main/java/com/pm/wordi/controller/dto/MentoringDto.java
@@ -1,7 +1,9 @@
 package com.pm.wordi.controller.dto;
 
+import com.pm.wordi.controller.dto.MentorDto.ScheduleDTO;
 import com.pm.wordi.domain.BaseStatus;
 import com.pm.wordi.domain.mentor.Mentor;
+import com.pm.wordi.domain.mentor.MentorSchedule;
 import com.pm.wordi.domain.mentoring.Mentoring;
 import com.pm.wordi.domain.mentoring.MentoringStatus;
 import com.pm.wordi.domain.mentoring.Payment;
@@ -12,8 +14,16 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.validation.annotation.Validated;
 
+import javax.validation.Valid;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.NotNull;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
 
 public class MentoringDto {
 
@@ -22,12 +32,19 @@ public class MentoringDto {
     @NoArgsConstructor(access = AccessLevel.PROTECTED)
     public static class CreateRequest {
 
+        @NotNull(message = "가격 정보가 입력되지 않았습니다.")
         private Long price;
+
         @DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
         private LocalDateTime requestSchedule1;
+
         @DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
         private LocalDateTime requestSchedule2;
+
+        @NotBlank(message = "사전 질문을 기입해주세요.")
         private String questions;
+
+        @Valid
         private paymentDTO payment;
 
         public Mentoring toEntity(User user, Mentor mentor, Payment payment) {
@@ -52,8 +69,13 @@ public class MentoringDto {
     @AllArgsConstructor
     @NoArgsConstructor(access = AccessLevel.PROTECTED)
     public static class paymentDTO {
+
+        @NotBlank(message = "주문번호가 입력되지 않았습니다.")
         private String orderNumber;
+
+        @NotNull(message = "가격 정보가 입력되지 않았습니다.")
         private Long price;
+
         private String depositor;
         private String bankCode;
         private String accountNumber;
@@ -69,6 +91,25 @@ public class MentoringDto {
                     .paymentStatus(PaymentStatus.결제보류)
                     .status(BaseStatus.ACTIVE)
                     .build();
+        }
+    }
+
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    public static class MentoringRes {
+        private String nickname;
+        private String mentorNation;
+        private Long price;
+        private List<ScheduleDTO> mentorScheduleList = new ArrayList<>();
+
+        public MentoringRes(Mentor mentor) {
+            this.nickname = mentor.getUser().getNickname();
+            this.mentorNation = mentor.getNation();
+            this.price = mentor.getPrice();
+            this.mentorScheduleList = mentor.getMentorScheduleList().stream()
+                    .map(ScheduleDTO::new)
+                    .collect(Collectors.toList());
         }
     }
 }

--- a/server/wordi/src/main/java/com/pm/wordi/controller/dto/MentoringDto.java
+++ b/server/wordi/src/main/java/com/pm/wordi/controller/dto/MentoringDto.java
@@ -30,7 +30,7 @@ public class MentoringDto {
     @Getter
     @AllArgsConstructor
     @NoArgsConstructor(access = AccessLevel.PROTECTED)
-    public static class CreateRequest {
+    public static class ApplicationReq {
 
         @NotNull(message = "가격 정보가 입력되지 않았습니다.")
         private Long price;
@@ -97,13 +97,13 @@ public class MentoringDto {
     @Getter
     @AllArgsConstructor
     @NoArgsConstructor(access = AccessLevel.PROTECTED)
-    public static class MentoringRes {
+    public static class ApplicationRes {
         private String nickname;
         private String mentorNation;
         private Long price;
         private List<ScheduleDTO> mentorScheduleList = new ArrayList<>();
 
-        public MentoringRes(Mentor mentor) {
+        public ApplicationRes(Mentor mentor) {
             this.nickname = mentor.getUser().getNickname();
             this.mentorNation = mentor.getNation();
             this.price = mentor.getPrice();
@@ -112,4 +112,41 @@ public class MentoringDto {
                     .collect(Collectors.toList());
         }
     }
+
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    public static class MentorMentoringRes {
+        private Long id;
+        private MentoringStatus mentoringStatus;
+        private String userNickname;
+        private LocalDateTime requestSchedule1;
+        private LocalDateTime requestSchedule2;
+        private String questions;
+
+        public MentorMentoringRes(Mentoring mentoring) {
+            this.id = mentoring.getId();
+            this.mentoringStatus = mentoring.getMentoringStatus();
+            this.userNickname = mentoring.getUser().getNickname();
+            this.requestSchedule1 = mentoring.getRequestSchedule1();
+            this.requestSchedule2 = mentoring.getRequestSchedule2();
+            this.questions = mentoring.getQuestions();
+        }
+    }
+
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    public static class UserMentoringRes {
+        private Long mentoringId;
+        private Long paymentId;
+        private MentoringStatus mentoringStatus;
+        private String mentorNickname;
+        private String mentorNation;
+        private List<String> keywords;
+        private LocalDateTime requestSchedule1;
+        private LocalDateTime requestSchedule2;
+        private String questions;
+    }
+
 }

--- a/server/wordi/src/main/java/com/pm/wordi/controller/dto/MentoringDto.java
+++ b/server/wordi/src/main/java/com/pm/wordi/controller/dto/MentoringDto.java
@@ -117,19 +117,23 @@ public class MentoringDto {
     @AllArgsConstructor
     @NoArgsConstructor(access = AccessLevel.PROTECTED)
     public static class MentorMentoringRes {
-        private Long id;
+        private Long mentoringId;
+        private Long paymentId;
         private MentoringStatus mentoringStatus;
         private String userNickname;
         private LocalDateTime requestSchedule1;
         private LocalDateTime requestSchedule2;
+        private LocalDateTime selectedSchedule;
         private String questions;
 
         public MentorMentoringRes(Mentoring mentoring) {
-            this.id = mentoring.getId();
+            this.mentoringId = mentoring.getId();
+            this.paymentId = mentoring.getPayment().getId();
             this.mentoringStatus = mentoring.getMentoringStatus();
             this.userNickname = mentoring.getUser().getNickname();
             this.requestSchedule1 = mentoring.getRequestSchedule1();
             this.requestSchedule2 = mentoring.getRequestSchedule2();
+            this.selectedSchedule = mentoring.getSelectedSchedule();
             this.questions = mentoring.getQuestions();
         }
     }
@@ -146,7 +150,23 @@ public class MentoringDto {
         private List<String> keywords;
         private LocalDateTime requestSchedule1;
         private LocalDateTime requestSchedule2;
+        private LocalDateTime selectedSchedule;
         private String questions;
+
+        public UserMentoringRes(Mentoring mentoring) {
+            this.mentoringId = mentoring.getId();
+            this.paymentId = mentoring.getPayment().getId();
+            this.mentoringStatus = mentoring.getMentoringStatus();
+            this.mentorNickname = mentoring.getMentor().getUser().getNickname();
+            this.mentorNation = mentoring.getMentor().getNation();
+            this.keywords = mentoring.getMentor().getMentorKeywordList().stream()
+                    .map(k -> k.getKeyword())
+                    .collect(Collectors.toList());
+            this.requestSchedule1 = mentoring.getRequestSchedule1();
+            this.requestSchedule2 = mentoring.getRequestSchedule2();
+            this.selectedSchedule = mentoring.getSelectedSchedule();
+            this.questions = mentoring.getQuestions();
+        }
     }
 
 }

--- a/server/wordi/src/main/java/com/pm/wordi/domain/mentor/Mentor.java
+++ b/server/wordi/src/main/java/com/pm/wordi/domain/mentor/Mentor.java
@@ -14,6 +14,7 @@ import javax.persistence.*;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 import static com.pm.wordi.controller.dto.MentorDto.*;
 
@@ -69,6 +70,31 @@ public class Mentor extends BaseTimeEntity {
 
     @Enumerated(EnumType.STRING)
     private BaseStatus status;
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Mentor mentor = (Mentor) o;
+        return isProgress == mentor.isProgress && Objects.equals(id, mentor.id) && Objects.equals(user, mentor.user)
+                && Objects.equals(mentorKeywordList, mentor.mentorKeywordList)
+                && Objects.equals(mentorScheduleList, mentor.mentorScheduleList)
+                && Objects.equals(reviewList, mentor.reviewList) && Objects.equals(mentoringList, mentor.mentoringList)
+                && Objects.equals(nation, mentor.nation) && Objects.equals(startDate, mentor.startDate)
+                && Objects.equals(endDate, mentor.endDate) && Objects.equals(profileImageUrl, mentor.profileImageUrl)
+                && Objects.equals(profileIntroduction, mentor.profileIntroduction)
+                && Objects.equals(introduction, mentor.introduction) && Objects.equals(price, mentor.price)
+                && Objects.equals(entryCertification, mentor.entryCertification)
+                && Objects.equals(certification, mentor.certification) && mentorLevel == mentor.mentorLevel
+                && status == mentor.status;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, user, mentorKeywordList, mentorScheduleList, reviewList, mentoringList,
+                nation, startDate, endDate, isProgress, profileImageUrl, profileIntroduction, introduction,
+                price, entryCertification, certification, mentorLevel, status);
+    }
 
     // == 연관관계 편의 메서드
     public void addMentorKeywordList(MentorKeyword mentorKeyword) {

--- a/server/wordi/src/main/java/com/pm/wordi/domain/mentor/MentorRepository.java
+++ b/server/wordi/src/main/java/com/pm/wordi/domain/mentor/MentorRepository.java
@@ -24,5 +24,8 @@ public interface MentorRepository extends JpaRepository<Mentor, Long> {
     @EntityGraph(attributePaths = {"mentorKeywordList"})
     Optional<Mentor> findByIdAndStatus(Long mentorId, BaseStatus status);
 
+    @EntityGraph(attributePaths = {"user"})
+    Optional<Mentor> findFetchUserByIdAndStatus(Long mentorId, BaseStatus status);
+
 
 }

--- a/server/wordi/src/main/java/com/pm/wordi/domain/mentor/MentorRepository.java
+++ b/server/wordi/src/main/java/com/pm/wordi/domain/mentor/MentorRepository.java
@@ -21,7 +21,7 @@ public interface MentorRepository extends JpaRepository<Mentor, Long> {
     @Query("select m from Mentor m where m.status = 'ACTIVE' order by m.id desc")
     List<Mentor> searchProfileList();
 
-    @EntityGraph(attributePaths = {"mentorKeywordList"})
+    @EntityGraph(attributePaths = {"mentorScheduleList"})
     Optional<Mentor> findByIdAndStatus(Long mentorId, BaseStatus status);
 
     @EntityGraph(attributePaths = {"user"})

--- a/server/wordi/src/main/java/com/pm/wordi/domain/mentor/MentorRepository.java
+++ b/server/wordi/src/main/java/com/pm/wordi/domain/mentor/MentorRepository.java
@@ -15,7 +15,7 @@ public interface MentorRepository extends JpaRepository<Mentor, Long> {
     Long countByUser(User user);
 
     @EntityGraph(attributePaths = {"mentorKeywordList"})
-    Optional<Mentor> findProfileByUserIdAndStatus(Long userId, BaseStatus status);
+    Optional<Mentor> findByUserIdAndStatus(Long userId, BaseStatus status);
 
     @EntityGraph(attributePaths = {"user"})
     @Query("select m from Mentor m where m.status = 'ACTIVE' order by m.id desc")

--- a/server/wordi/src/main/java/com/pm/wordi/domain/mentoring/Mentoring.java
+++ b/server/wordi/src/main/java/com/pm/wordi/domain/mentoring/Mentoring.java
@@ -5,6 +5,7 @@ import com.pm.wordi.domain.BaseTimeEntity;
 import com.pm.wordi.domain.mentor.Mentor;
 import com.pm.wordi.domain.user.User;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -52,5 +53,20 @@ public class Mentoring extends BaseTimeEntity {
 
     public void updateMentor(Mentor mentor) {
         this.mentor = mentor;
+    }
+
+    @Builder
+    public Mentoring(User user, Mentor mentor, Payment payment, Long price,
+                     LocalDateTime requestSchedule1, LocalDateTime requestSchedule2,
+                     String questions, MentoringStatus mentoringStatus, BaseStatus status) {
+        this.user = user;
+        this.mentor = mentor;
+        this.payment = payment;
+        this.price = price;
+        this.requestSchedule1 = requestSchedule1;
+        this.requestSchedule2 = requestSchedule2;
+        this.questions = questions;
+        this.mentoringStatus = mentoringStatus;
+        this.status = status;
     }
 }

--- a/server/wordi/src/main/java/com/pm/wordi/domain/mentoring/Mentoring.java
+++ b/server/wordi/src/main/java/com/pm/wordi/domain/mentoring/Mentoring.java
@@ -40,6 +40,8 @@ public class Mentoring extends BaseTimeEntity {
 
     private LocalDateTime requestSchedule2;
 
+    private LocalDateTime selectedSchedule;
+
     private String questions;
 
     @Enumerated(EnumType.STRING)

--- a/server/wordi/src/main/java/com/pm/wordi/domain/mentoring/MentoringRepository.java
+++ b/server/wordi/src/main/java/com/pm/wordi/domain/mentoring/MentoringRepository.java
@@ -1,0 +1,6 @@
+package com.pm.wordi.domain.mentoring;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MentoringRepository extends JpaRepository<Mentoring, Long> {
+}

--- a/server/wordi/src/main/java/com/pm/wordi/domain/mentoring/MentoringRepository.java
+++ b/server/wordi/src/main/java/com/pm/wordi/domain/mentoring/MentoringRepository.java
@@ -1,11 +1,17 @@
 package com.pm.wordi.domain.mentoring;
 
 import com.pm.wordi.domain.BaseStatus;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
 
 public interface MentoringRepository extends JpaRepository<Mentoring, Long> {
 
+    @EntityGraph(attributePaths = {"payment"})
     List<Mentoring> findAllByMentorIdAndStatus(Long mentorId, BaseStatus baseStatus);
+
+    @EntityGraph(attributePaths = {"payment", "mentor"})
+    List<Mentoring> findAllByUserIdAndStatus(Long userId, BaseStatus baseStatus);
+
 }

--- a/server/wordi/src/main/java/com/pm/wordi/domain/mentoring/MentoringRepository.java
+++ b/server/wordi/src/main/java/com/pm/wordi/domain/mentoring/MentoringRepository.java
@@ -1,6 +1,11 @@
 package com.pm.wordi.domain.mentoring;
 
+import com.pm.wordi.domain.BaseStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface MentoringRepository extends JpaRepository<Mentoring, Long> {
+
+    List<Mentoring> findAllByMentorIdAndStatus(Long mentorId, BaseStatus baseStatus);
 }

--- a/server/wordi/src/main/java/com/pm/wordi/domain/mentoring/Payment.java
+++ b/server/wordi/src/main/java/com/pm/wordi/domain/mentoring/Payment.java
@@ -4,6 +4,7 @@ import com.pm.wordi.domain.BaseStatus;
 import com.pm.wordi.domain.BaseTimeEntity;
 import com.pm.wordi.domain.user.User;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -39,5 +40,16 @@ public class Payment extends BaseTimeEntity {
     @Enumerated(EnumType.STRING)
     private BaseStatus status;
 
-
+    @Builder
+    public Payment(User user, String orderNumber, Long price, String depositor, String bankCode,
+                   String accountNumber, PaymentStatus paymentStatus, BaseStatus status) {
+        this.user = user;
+        this.orderNumber = orderNumber;
+        this.price = price;
+        this.depositor = depositor;
+        this.bankCode = bankCode;
+        this.accountNumber = accountNumber;
+        this.paymentStatus = paymentStatus;
+        this.status = status;
+    }
 }

--- a/server/wordi/src/main/java/com/pm/wordi/domain/mentoring/PaymentRepository.java
+++ b/server/wordi/src/main/java/com/pm/wordi/domain/mentoring/PaymentRepository.java
@@ -1,0 +1,6 @@
+package com.pm.wordi.domain.mentoring;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PaymentRepository extends JpaRepository<Payment, Long> {
+}

--- a/server/wordi/src/main/java/com/pm/wordi/domain/mentoring/PaymentStatus.java
+++ b/server/wordi/src/main/java/com/pm/wordi/domain/mentoring/PaymentStatus.java
@@ -1,5 +1,5 @@
 package com.pm.wordi.domain.mentoring;
 
 public enum PaymentStatus {
-    결제대기, 결제완료, 결제취소, 환불
+    결제보류, 결제완료, 결제취소, 환불
 }

--- a/server/wordi/src/main/java/com/pm/wordi/domain/user/User.java
+++ b/server/wordi/src/main/java/com/pm/wordi/domain/user/User.java
@@ -11,6 +11,7 @@ import javax.persistence.*;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 import static com.pm.wordi.controller.dto.UserDto.*;
 
@@ -55,6 +56,25 @@ public class User extends BaseTimeEntity {
     @Enumerated(EnumType.STRING)
     private BaseStatus status;
 
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        User user = (User) o;
+        return isMentor == user.isMentor && isOAuth2 == user.isOAuth2 && Objects.equals(id, user.id)
+                && Objects.equals(userKeywordList, user.userKeywordList) && Objects.equals(email, user.email)
+                && Objects.equals(password, user.password) && Objects.equals(phoneNumber, user.phoneNumber)
+                && Objects.equals(nickname, user.nickname) && Objects.equals(nation1, user.nation1)
+                && Objects.equals(nation2, user.nation2) && Objects.equals(nation3, user.nation3)
+                && userLevel == user.userLevel && status == user.status;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, userKeywordList, email, password, phoneNumber, nickname,
+                nation1, nation2, nation3, userLevel, isMentor, isOAuth2, status);
+    }
 
     // == 연관관계 편의 메서드 ==
     public void addKeyword(UserKeyword userKeyword) {

--- a/server/wordi/src/main/java/com/pm/wordi/exception/mentoring/EqualUserMentorException.java
+++ b/server/wordi/src/main/java/com/pm/wordi/exception/mentoring/EqualUserMentorException.java
@@ -1,0 +1,11 @@
+package com.pm.wordi.exception.mentoring;
+
+public class EqualUserMentorException extends RuntimeException{
+    public EqualUserMentorException() {
+        super();
+    }
+
+    public EqualUserMentorException(String message) {
+        super(message);
+    }
+}

--- a/server/wordi/src/main/java/com/pm/wordi/service/MentorService.java
+++ b/server/wordi/src/main/java/com/pm/wordi/service/MentorService.java
@@ -77,12 +77,14 @@ public class MentorService {
 
     }
 
+    @Transactional(readOnly = true)
     public List<ProfileListRes> searchProfileList() {
         return mentorRepository.searchProfileList().stream()
                 .map(ProfileListRes::new)
                 .collect(Collectors.toList());
     }
 
+    @Transactional(readOnly = true)
     public MentoringProfileRes getMentoringProfile(Long mentorId) {
         return mentorRepository.findByIdAndStatus(mentorId, ACTIVE)
                 .map(MentoringProfileRes::new)

--- a/server/wordi/src/main/java/com/pm/wordi/service/MentorService.java
+++ b/server/wordi/src/main/java/com/pm/wordi/service/MentorService.java
@@ -51,7 +51,7 @@ public class MentorService {
 
     @Transactional(readOnly = true)
     public ProfileRes getProfile(Long userId) {
-        return mentorRepository.findProfileByUserIdAndStatus(userId, ACTIVE)
+        return mentorRepository.findByUserIdAndStatus(userId, ACTIVE)
                 .map(ProfileRes::new)
                 .orElseThrow(() -> new NoExistMentorException("해당 회원의 멘토 정보가 존재하지 않습니다."));
 
@@ -60,7 +60,7 @@ public class MentorService {
     @Transactional
     public void updateProfile(Long userId, ProfileReq profileReq) {
 
-        Mentor mentor = mentorRepository.findProfileByUserIdAndStatus(userId, ACTIVE)
+        Mentor mentor = mentorRepository.findByUserIdAndStatus(userId, ACTIVE)
                 .orElseThrow(() -> new NoExistMentorException("해당 회원의 멘토 정보가 존재하지 않습니다."));
 
         mentor.updateProfile(profileReq);

--- a/server/wordi/src/main/java/com/pm/wordi/service/MentoringService.java
+++ b/server/wordi/src/main/java/com/pm/wordi/service/MentoringService.java
@@ -1,0 +1,50 @@
+package com.pm.wordi.service;
+
+import com.pm.wordi.controller.dto.MentoringDto;
+import com.pm.wordi.domain.BaseStatus;
+import com.pm.wordi.domain.mentor.Mentor;
+import com.pm.wordi.domain.mentor.MentorRepository;
+import com.pm.wordi.domain.mentoring.MentoringRepository;
+import com.pm.wordi.domain.mentoring.Payment;
+import com.pm.wordi.domain.mentoring.PaymentRepository;
+import com.pm.wordi.domain.user.User;
+import com.pm.wordi.domain.user.UserRepository;
+import com.pm.wordi.exception.mentor.NoExistMentoringProfileException;
+import com.pm.wordi.exception.mentoring.EqualUserMentorException;
+import com.pm.wordi.exception.user.NoExistUserException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import static com.pm.wordi.domain.BaseStatus.*;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class MentoringService {
+
+    private final UserRepository userRepository;
+    private final MentorRepository mentorRepository;
+    private final MentoringRepository mentoringRepository;
+    private final PaymentRepository paymentRepository;
+
+    @Transactional
+    public void createMentoring(Long mentorId, Long userId, MentoringDto.CreateRequest createRequest) {
+
+        // 유저, 멘토 정보 조회
+        User user = userRepository.findByIdAndStatus(userId, ACTIVE)
+                .orElseThrow(() -> new NoExistUserException("접속하신 회원 정보가 존재하지 않습니다."));
+        Mentor mentor = mentorRepository.findFetchUserByIdAndStatus(mentorId, ACTIVE)
+                .orElseThrow(() -> new NoExistMentoringProfileException("신청하신 멘토링 멘토 정보가 존재하지 않습니다."));
+        if(mentor.getUser().equals(user)) {
+            throw new EqualUserMentorException("내 멘토링 서비스는 신청할 수 없습니다.");
+        }
+
+        // 결제 내역 저장
+        Payment payment = paymentRepository.save(createRequest.getPayment().toEntity(user));
+
+        // 멘토링 내역 저장
+        mentoringRepository.save(createRequest.toEntity(user, mentor, payment));
+
+    }
+}

--- a/server/wordi/src/main/java/com/pm/wordi/service/MentoringService.java
+++ b/server/wordi/src/main/java/com/pm/wordi/service/MentoringService.java
@@ -16,6 +16,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import static com.pm.wordi.controller.dto.MentoringDto.*;
 import static com.pm.wordi.domain.BaseStatus.*;
 
 @Service
@@ -29,7 +30,7 @@ public class MentoringService {
     private final PaymentRepository paymentRepository;
 
     @Transactional
-    public void createMentoring(Long mentorId, Long userId, MentoringDto.CreateRequest createRequest) {
+    public void createMentoring(Long mentorId, Long userId, CreateRequest createRequest) {
 
         // 유저, 멘토 정보 조회
         User user = userRepository.findByIdAndStatus(userId, ACTIVE)
@@ -46,5 +47,20 @@ public class MentoringService {
         // 멘토링 내역 저장
         mentoringRepository.save(createRequest.toEntity(user, mentor, payment));
 
+    }
+
+    public MentoringRes getMentoring(Long mentorId, Long userId) {
+
+        User user = userRepository.findByIdAndStatus(userId, ACTIVE)
+                .orElseThrow(() -> new NoExistUserException("접속하신 회원 정보가 존재하지 않습니다."));
+        MentoringRes mentoringRes = mentorRepository.findByIdAndStatus(mentorId, ACTIVE)
+                .map(MentoringRes::new)
+                .orElseThrow(() -> new NoExistMentoringProfileException("신청하신 멘토링 멘토 정보가 존재하지 않습니다."));
+
+        if(mentoringRes.getNickname().equals(user.getNickname())) {
+            throw new EqualUserMentorException("내 멘토링 서비스는 신청할 수 없습니다.");
+        }
+
+        return mentoringRes;
     }
 }

--- a/server/wordi/src/main/java/com/pm/wordi/service/MentoringService.java
+++ b/server/wordi/src/main/java/com/pm/wordi/service/MentoringService.java
@@ -51,6 +51,7 @@ public class MentoringService {
 
     }
 
+    @Transactional(readOnly = true)
     public ApplicationRes getMentoring(Long mentorId, Long userId) {
 
         User user = userRepository.findByIdAndStatus(userId, ACTIVE)
@@ -66,6 +67,7 @@ public class MentoringService {
         return applicationRes;
     }
 
+    @Transactional(readOnly = true)
     public List<MentorMentoringRes> geMentoringListBytMentor(Long userId) {
 
         Mentor mentor = mentorRepository.findByUserIdAndStatus(userId, ACTIVE)
@@ -73,6 +75,13 @@ public class MentoringService {
 
         return mentoringRepository.findAllByMentorIdAndStatus(mentor.getId(), ACTIVE).stream()
                 .map(MentorMentoringRes::new)
+                .collect(Collectors.toList());
+    }
+
+    @Transactional(readOnly = true)
+    public List<UserMentoringRes> geMentoringListByUser(Long userId) {
+        return mentoringRepository.findAllByUserIdAndStatus(userId, ACTIVE).stream()
+                .map(UserMentoringRes::new)
                 .collect(Collectors.toList());
     }
 }


### PR DESCRIPTION
## 작업 상세
- 관련 이슈: #86 
- 멘토링 신청 API 구현
- 멘토링 신청 페이지 API 구현
- 워디 멘토 활동 내역 API 구현
- 유저 멘토링 신청 내역 API 구현

## 추가 사항
- 멘토링 Entity에 SelectedSchedule 추가.
